### PR TITLE
use buffer size of utf8 string

### DIFF
--- a/lib/radius.js
+++ b/lib/radius.js
@@ -538,11 +538,12 @@ Radius.decrypt_field = function(field) {
 };
 
 Radius.encrypt_field = function(field) {
-  var buf = new Buffer(field.length + 15 - ((15 + field.length) % 16));
-  buf.write(field, 0, field.length);
+  var len = Buffer.byteLength(field, 'utf8');
+  var buf = new Buffer(len + 15 - ((15 + len) % 16));
+  buf.write(field, 0, len);
 
   // null-out the padding
-  for (var i = field.length; i < buf.length; i++) {
+  for (var i = len; i < buf.length; i++) {
     buf[i] = 0x00;
   }
 


### PR DESCRIPTION
I thank you for your nice node module for radius.
Days ago I found this: If the password is in UTF8, it may be truncated.

Please kindly review if this can solve this issue.
