### PR TITLE
travis node lts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - lts/*
+  - 6
   - "0.10"
   - "0.12"
   - "4.3"


### PR DESCRIPTION
* adds lts versions to travis configuration

it's not obvious, but `lts/*` is a shorthand for switching to the most current lts release (in this case node 8)