### PR TITLE
parse dictionary values in hex format 0x32

### DIFF
--- a/lib/radius.js
+++ b/lib/radius.js
@@ -88,7 +88,7 @@ Radius.load_dictionary = function(file, seen_files) {
 
 Radius._load_dictionary = function(content) {
   var lines = content.split("\n");
-
+  var val;
   var vendor = NO_VENDOR, includes = [], attr_vendor;
   for (var i = 0; i < lines.length; i++) {
     var line = lines[i];
@@ -156,7 +156,7 @@ Radius._load_dictionary = function(content) {
       continue;
     }
 
-    match = line.match(/^\s*(?:VENDOR)?VALUE\s+(\d+)?\s*(\S+)\s+(\S+)\s+(\d+)/);
+    match = line.match(/^\s*(?:VENDOR)?VALUE\s+(\d+)?\s*(\S+)\s+(\S+)\s+(\S+)/);
     if (match) {
       attr_vendor = vendor;
       if (match[1] !== undefined) {
@@ -165,8 +165,9 @@ Radius._load_dictionary = function(content) {
 
       init_entry(attr_vendor, match[2]);
 
-      attributes_map[attr_vendor][match[2]][ATTR_ENUM][match[4]] = match[3];
-      attributes_map[attr_vendor][match[2]][ATTR_REVERSE_ENUM][match[3]] = match[4];
+      val = parseInt(match[4]);
+      attributes_map[attr_vendor][match[2]][ATTR_ENUM][val] = match[3];
+      attributes_map[attr_vendor][match[2]][ATTR_REVERSE_ENUM][match[3]] = val;
 
       continue;
     }


### PR DESCRIPTION
Parse dictionary values that are hex format, e.g. 0x10.   Should also parse octal values.