### PR TITLE
Update radius.js

### DIFF
--- a/lib/radius.js
+++ b/lib/radius.js
@@ -263,7 +263,7 @@ var is_request_code = {
 var reverse_code_map = {};
 for (var code in code_map) {
   reverse_code_map[code_map[code]] = code;
-  if (code_map[code].match(/Request/)) {
+  if (code_map[code].toString().match(/Request/)) {
     is_request_code[code_map[code]] = true;
   }
 }


### PR DESCRIPTION
When the value of code = 'IS_WINDOWS' code_map[code] returns a boolean value which causes the match method to throw an error. Converting the value to string resolves this error.