### PR TITLE
Removes use of deprecated Buffer constructor

### DIFF
--- a/lib/radius.js
+++ b/lib/radius.js
@@ -804,7 +804,7 @@ Radius.encode_attributes = function(packet, attributes, vendor) {
           out_value = Buffer.from(in_value + "", "utf8");
           break;
         case "ipaddr":
-          out_value = Buffer.from(in_value.split('.'));
+          out_value = Buffer.from(in_value.split("."));
           if (out_value.length != 4) {
             throw new Error("encode: invalid IP: " + in_value);
           }

--- a/lib/radius.js
+++ b/lib/radius.js
@@ -329,7 +329,7 @@ Radius.decode = function(args) {
   }
 
   if (!uses_random_authenticator[ret.code] && is_request_code[ret.code] && !args.no_secret) {
-    var orig_authenticator = new Buffer(AUTH_LENGTH);
+    var orig_authenticator = Buffer.alloc(AUTH_LENGTH);
     packet.copy(orig_authenticator, 0, AUTH_START, AUTH_END);
     packet.fill(0, AUTH_START, AUTH_END);
 
@@ -355,8 +355,7 @@ Radius.zero_out_message_authenticator = function(attributes) {
   for (var i = 0; i < new_attrs.length; i++) {
     var attr = new_attrs[i];
     if (attr[0] == ma_id) {
-      new_attrs[i] = [ma_id, new Buffer(MESSAGE_AUTHENTICATOR_LENGTH)];
-      new_attrs[i][1].fill(0x00);
+      new_attrs[i] = [ma_id, Buffer.alloc(MESSAGE_AUTHENTICATOR_LENGTH)];
       break;
     }
   }
@@ -395,7 +394,7 @@ Radius.verify_response = function(args) {
   }
 
   // first verify authenticator
-  var got_checksum = new Buffer(AUTH_LENGTH);
+  var got_checksum = Buffer.alloc(AUTH_LENGTH);
   args.response.copy(got_checksum, 0, AUTH_START, AUTH_END);
   args.request.copy(args.response, AUTH_START, AUTH_START, AUTH_END);
 
@@ -494,7 +493,7 @@ Radius.decode_attributes = function(data, attr_hash, vendor, raw_attrs) {
       case "time":
       case "integer":
         if (attr_info[ATTR_MODIFIERS]["has_tag"]) {
-          var buf = new Buffer([0, 0, 0, 0]);
+          var buf = Buffer.alloc(4);
           value.copy(buf, 1);
           value = buf;
         }
@@ -559,19 +558,13 @@ Radius.decrypt_field = function(field) {
 
 Radius.encrypt_field = function(field) {
   var len = Buffer.byteLength(field, 'utf8');
-  var buf = new Buffer(len + 15 - ((15 + len) % 16));
+  var buf = Buffer.alloc(len + 15 - ((15 + len) % 16));
   buf.write(field, 0, len);
-
-  // null-out the padding
-  for (var i = len; i < buf.length; i++) {
-    buf[i] = 0x00;
-  }
-
   return this._crypt_field(buf, false);
 };
 
 Radius._crypt_field = function(field, is_decrypt) {
-  var ret = new Buffer(0);
+  var ret = Buffer.allocUnsafe(0);
   var second_part_to_be_hashed = this.authenticator;
 
   if (this.secret === undefined) {
@@ -582,9 +575,9 @@ Radius._crypt_field = function(field, is_decrypt) {
     var hasher = crypto.createHash("md5");
     hasher.update(this.secret);
     hasher.update(second_part_to_be_hashed);
-    var hash = new Buffer(hasher.digest("binary"), "binary");
+    var hash = Buffer.from(hasher.digest("binary"), "binary");
 
-    var xor_result = new Buffer(16);
+    var xor_result = Buffer.alloc(16);
     for (var j = 0; j < 16; j++) {
       xor_result[j] = field[i + j] ^ hash[j];
       if (is_decrypt && xor_result[j] == 0x00) {
@@ -645,7 +638,7 @@ Radius.encode = function(args) {
     return;
   }
 
-  var packet = new Buffer(4096);
+  var packet = Buffer.alloc(4096);
   var offset = 0;
 
   var code = reverse_code_map[args.code];
@@ -675,7 +668,7 @@ Radius.encode = function(args) {
     if (uses_random_authenticator[args.code]) {
       authenticator = crypto.randomBytes(AUTH_LENGTH);
     } else {
-      authenticator = new Buffer(AUTH_LENGTH);
+      authenticator = Buffer.alloc(AUTH_LENGTH);
       authenticator.fill(0x00);
     }
   }
@@ -712,8 +705,7 @@ Radius._encode_with_authenticator = function(args, packet, offset, authenticator
   }
 
   if (add_message_authenticator) {
-    var empty_authenticator = new Buffer(MESSAGE_AUTHENTICATOR_LENGTH);
-    empty_authenticator.fill(0x00);
+    var empty_authenticator = Buffer.alloc(MESSAGE_AUTHENTICATOR_LENGTH);
     args.attributes.push(["Message-Authenticator", empty_authenticator]);
   }
 
@@ -750,14 +742,14 @@ Radius._encode_with_authenticator = function(args, packet, offset, authenticator
 Radius.calculate_message_authenticator = function(packet, secret) {
   var hmac = crypto.createHmac('md5', secret);
   hmac.update(packet);
-  return new Buffer(hmac.digest('binary'), 'binary');
+  return Buffer.from(hmac.digest('binary'), 'binary');
 };
 
 Radius.calculate_packet_checksum = function(packet, secret) {
   var hasher = crypto.createHash("md5");
   hasher.update(packet);
   hasher.update(secret);
-  return new Buffer(hasher.digest("binary"), "binary");
+  return Buffer.from(hasher.digest("binary"), "binary");
 };
 
 Radius.ensure_array_attributes = function(attributes) {
@@ -785,13 +777,13 @@ Radius.encode_attributes = function(packet, attributes, vendor) {
   for (var i = 0; i < attributes.length; i++) {
     var attr = attributes[i];
     var attr_info = attributes_map[vendor] && attributes_map[vendor][attr[0]];
-    if (!attr_info && !(attr[1] instanceof Buffer)) {
+    if (!attr_info && !(Buffer.isBuffer(attr[1]))) {
       throw new Error("encode: invalid attributes - must give Buffer for " +
         "unknown attribute '" + attr[0] + "'");
     }
 
     var out_value, in_value = attr[1];
-    if (in_value instanceof Buffer) {
+    if (Buffer.isBuffer(in_value)) {
       out_value = in_value;
     } else {
       var has_tag = attr_info[ATTR_MODIFIERS]["has_tag"] && attr.length == 3;
@@ -809,10 +801,10 @@ Radius.encode_attributes = function(packet, attributes, vendor) {
           if (in_value.length == 0) {
             continue;
           }
-          out_value = new Buffer(in_value + "", "utf8");
+          out_value = Buffer.from(in_value + "", "utf8");
           break;
         case "ipaddr":
-          out_value = new Buffer(in_value.split("."));
+          out_value = Buffer.from(in_value.split('.'));
           if (out_value.length != 4) {
             throw new Error("encode: invalid IP: " + in_value);
           }
@@ -821,7 +813,7 @@ Radius.encode_attributes = function(packet, attributes, vendor) {
           in_value = Math.floor(in_value.getTime() / 1000);
         case "time":
         case "integer":
-          out_value = new Buffer(4);
+          out_value = Buffer.alloc(4);
 
           in_value = attr_info[ATTR_REVERSE_ENUM][in_value] || in_value;
           if (isNaN(in_value)) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "git://github.com/nearbuy/node-radius.git"
   },
-  "engines": { "node": ">=0.8.0" },
+  "engines": { "node": ">=5.10.0" },
   "devDependencies": {
     "nodeunit": "~0.8.6"
   },

--- a/test/radius.test.js
+++ b/test/radius.test.js
@@ -42,7 +42,7 @@ module.exports = testCase({
         'Aruba-Location-Id': '00:1a:1e:c6:b0:ca',
         'Aruba-AP-Group': 'cloud-cp'
       },
-      'Message-Authenticator': new Buffer('f8a12329c7ed5a6e2568515243efb918', 'hex')
+      'Message-Authenticator': Buffer.from('f8a12329c7ed5a6e2568515243efb918', 'hex')
     };
     test.deepEqual( decoded.attributes, expected_attrs );
 
@@ -74,7 +74,7 @@ module.exports = testCase({
         'Aruba-Location-Id': '00:1a:1e:c6:b0:ca',
         'Aruba-AP-Group': 'cloud-cp'
       },
-      'Message-Authenticator': new Buffer('f8a12329c7ed5a6e2568515243efb918', 'hex')
+      'Message-Authenticator': Buffer.from('f8a12329c7ed5a6e2568515243efb918', 'hex')
     };
     test.deepEqual( decoded.attributes, expected_attrs );
 
@@ -113,18 +113,18 @@ module.exports = testCase({
     test.deepEqual( decoded.attributes, {} );
 
     var expected_raw_attrs = [
-      [4, new Buffer([10, 0, 0, 90])],
-      [5, new Buffer([0, 0, 0, 0])],
-      [61, new Buffer([0, 0, 0, 19])],
-      [1, new Buffer('7c:c5:37:ff:f8:af')],
-      [2, new Buffer('eb2ef7e83ec1a05e04fb5c6d91e088569a990fa2b1b2dc6a0f048596081164cd', 'hex')],
-      [31, new Buffer('7CC537FFF8AF')],
-      [30, new Buffer('000B86F02068')],
-      [6, new Buffer([0, 0, 0, 1])],
-      [26, new Buffer('000039e705126d7569722d61727562612d6775657374', 'hex')],
-      [26, new Buffer('000039e7061330303a31613a31653a63363a62303a6361', 'hex')],
-      [26, new Buffer('000039e70a0a636c6f75642d6370', 'hex')],
-      [80, new Buffer('f8a12329c7ed5a6e2568515243efb918', 'hex')]
+      [4, Buffer.from([10, 0, 0, 90])],
+      [5, Buffer.from([0, 0, 0, 0])],
+      [61, Buffer.from([0, 0, 0, 19])],
+      [1, Buffer.from('7c:c5:37:ff:f8:af', 'utf8')],
+      [2, Buffer.from('eb2ef7e83ec1a05e04fb5c6d91e088569a990fa2b1b2dc6a0f048596081164cd', 'hex')],
+      [31, Buffer.from('7CC537FFF8AF', 'utf8')],
+      [30, Buffer.from('000B86F02068', 'utf8')],
+      [6, Buffer.from([0, 0, 0, 1])],
+      [26, Buffer.from('000039e705126d7569722d61727562612d6775657374', 'hex')],
+      [26, Buffer.from('000039e7061330303a31613a31653a63363a62303a6361', 'hex')],
+      [26, Buffer.from('000039e70a0a636c6f75642d6370', 'hex')],
+      [80, Buffer.from('f8a12329c7ed5a6e2568515243efb918', 'hex')]
     ];
 
     test.deepEqual( decoded.raw_attributes, expected_raw_attrs );
@@ -233,7 +233,7 @@ module.exports = testCase({
     var encoded = radius.encode({
       code: 'Access-Request',
       identifier: 58,
-      authenticator: new Buffer('4a45fae086d9e114286b37b5f371ec6c', 'hex'),
+      authenticator: Buffer.from('4a45fae086d9e114286b37b5f371ec6c', 'hex'),
       attributes: [
         ['NAS-IP-Address', '10.0.0.90'],
         ['NAS-Port', 0],
@@ -313,9 +313,9 @@ module.exports = testCase({
         secret: secret,
         attributes: [
           ['User-Name', 'ascribe-despairer'],
-          ['Proxy-State', new Buffer('womanhouse-Pseudotsuga')],
+          ['Proxy-State', Buffer.from('womanhouse-Pseudotsuga', 'utf8')],
           ['User-Password', 'ridiculous'],
-          ['Proxy-State', new Buffer('regretfully-unstability')]
+          ['Proxy-State', Buffer.from('regretfully-unstability', 'utf8')]
         ]
       }),
       secret: secret
@@ -331,8 +331,8 @@ module.exports = testCase({
     });
 
     var expected_raw_attributes = [
-      [radius.attr_name_to_id('Proxy-State'), new Buffer('womanhouse-Pseudotsuga')],
-      [radius.attr_name_to_id('Proxy-State'), new Buffer('regretfully-unstability')]
+      [radius.attr_name_to_id('Proxy-State'), Buffer.from('womanhouse-Pseudotsuga', 'utf8')],
+      [radius.attr_name_to_id('Proxy-State'), Buffer.from('regretfully-unstability', 'utf8')]
     ];
 
     test.deepEqual( decoded_response.raw_attributes, expected_raw_attributes );
@@ -345,7 +345,7 @@ module.exports = testCase({
     var decoded = radius.decode({
       packet: radius.encode({
         code: 'Access-Request',
-        authenticator: new Buffer('426edca213c1bf6e005e90a64105ca3a', 'hex'),
+        authenticator: Buffer.from('426edca213c1bf6e005e90a64105ca3a', 'hex'),
         attributes: [['User-Password', 'ridiculous']],
         secret: secret
       }),
@@ -640,11 +640,11 @@ module.exports = testCase({
     });
 
     // check we did the non-user-password authenticator
-    var got_authenticator = new Buffer(16);
+    var got_authenticator = Buffer.alloc(16);
     encoded.copy(got_authenticator, 0, 4);
     encoded.fill(0, 4, 20);
 
-    var expected_authenticator = new Buffer(16);
+    var expected_authenticator = Buffer.alloc(16);
     var hasher = crypto.createHash("md5");
     hasher.update(encoded);
     hasher.update(secret);
@@ -734,10 +734,10 @@ module.exports = testCase({
     });
 
     // check we are doing a random authenticator
-    var got_authenticator1 = new Buffer(16);
+    var got_authenticator1 = Buffer.alloc(16);
     encoded1.copy(got_authenticator1, 0, 4);
 
-    var got_authenticator2 = new Buffer(16);
+    var got_authenticator2 = Buffer.alloc(16);
     encoded2.copy(got_authenticator2, 0, 4);
 
     test.notEqual( got_authenticator1.toString(), got_authenticator2.toString() );
@@ -839,8 +839,7 @@ module.exports = testCase({
 
       // calculate expected Message-Authenticator
 
-      var empty = new Buffer(16);
-      empty.fill(0);
+      var empty = Buffer.alloc(16);
 
       var expected_response = radius.encode({
         code: "Access-Accept",


### PR DESCRIPTION
This patch updates the use of buffers to be in line with current standards.

The biggest upside is that buffers get zero-filled automatically when allocating them with `Buffer.alloc`, so we get to remove some manual zeroing and zero padding operations throughout the library.

I suppose the change I'm proposing here is no bueno if there's a desire to continue supporting users who are running Node versions prior to v5.10.0 (which is when `Buffer.alloc`, `Buffer.from`, and friends were introduced) without adding a nasty `process.version` conditional or something.

Really hoping that it's unlikely people still use such old versions of Node, though. Node 5 was almost an eternity ago... 🙈
