### PR TITLE
Fix the use of deprecated Buffer method

### DIFF
--- a/lib/radius.js
+++ b/lib/radius.js
@@ -329,7 +329,7 @@ Radius.decode = function(args) {
   }
 
   if (!uses_random_authenticator[ret.code] && is_request_code[ret.code] && !args.no_secret) {
-    var orig_authenticator = new Buffer(AUTH_LENGTH);
+    var orig_authenticator = Buffer.alloc(AUTH_LENGTH);
     packet.copy(orig_authenticator, 0, AUTH_START, AUTH_END);
     packet.fill(0, AUTH_START, AUTH_END);
 
@@ -355,7 +355,7 @@ Radius.zero_out_message_authenticator = function(attributes) {
   for (var i = 0; i < new_attrs.length; i++) {
     var attr = new_attrs[i];
     if (attr[0] == ma_id) {
-      new_attrs[i] = [ma_id, new Buffer(MESSAGE_AUTHENTICATOR_LENGTH)];
+      new_attrs[i] = [ma_id, Buffer.alloc(MESSAGE_AUTHENTICATOR_LENGTH)];
       new_attrs[i][1].fill(0x00);
       break;
     }
@@ -395,7 +395,7 @@ Radius.verify_response = function(args) {
   }
 
   // first verify authenticator
-  var got_checksum = new Buffer(AUTH_LENGTH);
+  var got_checksum = Buffer.alloc(AUTH_LENGTH);
   args.response.copy(got_checksum, 0, AUTH_START, AUTH_END);
   args.request.copy(args.response, AUTH_START, AUTH_START, AUTH_END);
 
@@ -494,7 +494,7 @@ Radius.decode_attributes = function(data, attr_hash, vendor, raw_attrs) {
       case "time":
       case "integer":
         if (attr_info[ATTR_MODIFIERS]["has_tag"]) {
-          var buf = new Buffer([0, 0, 0, 0]);
+          var buf = Buffer.alloc([0, 0, 0, 0]);
           value.copy(buf, 1);
           value = buf;
         }
@@ -559,7 +559,7 @@ Radius.decrypt_field = function(field) {
 
 Radius.encrypt_field = function(field) {
   var len = Buffer.byteLength(field, 'utf8');
-  var buf = new Buffer(len + 15 - ((15 + len) % 16));
+  var buf = Buffer.alloc(len + 15 - ((15 + len) % 16));
   buf.write(field, 0, len);
 
   // null-out the padding
@@ -571,7 +571,7 @@ Radius.encrypt_field = function(field) {
 };
 
 Radius._crypt_field = function(field, is_decrypt) {
-  var ret = new Buffer(0);
+  var ret = Buffer.alloc(0);
   var second_part_to_be_hashed = this.authenticator;
 
   if (this.secret === undefined) {
@@ -582,9 +582,9 @@ Radius._crypt_field = function(field, is_decrypt) {
     var hasher = crypto.createHash("md5");
     hasher.update(this.secret);
     hasher.update(second_part_to_be_hashed);
-    var hash = new Buffer(hasher.digest("binary"), "binary");
+    var hash = Buffer.alloc(hasher.digest("binary"), "binary");
 
-    var xor_result = new Buffer(16);
+    var xor_result = Buffer.alloc(16);
     for (var j = 0; j < 16; j++) {
       xor_result[j] = field[i + j] ^ hash[j];
       if (is_decrypt && xor_result[j] == 0x00) {
@@ -645,7 +645,7 @@ Radius.encode = function(args) {
     return;
   }
 
-  var packet = new Buffer(4096);
+  var packet = Buffer.alloc(4096);
   var offset = 0;
 
   var code = reverse_code_map[args.code];
@@ -675,7 +675,7 @@ Radius.encode = function(args) {
     if (uses_random_authenticator[args.code]) {
       authenticator = crypto.randomBytes(AUTH_LENGTH);
     } else {
-      authenticator = new Buffer(AUTH_LENGTH);
+      authenticator = Buffer.alloc(AUTH_LENGTH);
       authenticator.fill(0x00);
     }
   }
@@ -712,7 +712,7 @@ Radius._encode_with_authenticator = function(args, packet, offset, authenticator
   }
 
   if (add_message_authenticator) {
-    var empty_authenticator = new Buffer(MESSAGE_AUTHENTICATOR_LENGTH);
+    var empty_authenticator = Buffer.alloc(MESSAGE_AUTHENTICATOR_LENGTH);
     empty_authenticator.fill(0x00);
     args.attributes.push(["Message-Authenticator", empty_authenticator]);
   }
@@ -750,14 +750,14 @@ Radius._encode_with_authenticator = function(args, packet, offset, authenticator
 Radius.calculate_message_authenticator = function(packet, secret) {
   var hmac = crypto.createHmac('md5', secret);
   hmac.update(packet);
-  return new Buffer(hmac.digest('binary'), 'binary');
+  return Buffer.alloc(hmac.digest('binary'), 'binary');
 };
 
 Radius.calculate_packet_checksum = function(packet, secret) {
   var hasher = crypto.createHash("md5");
   hasher.update(packet);
   hasher.update(secret);
-  return new Buffer(hasher.digest("binary"), "binary");
+  return Buffer.alloc(hasher.digest("binary"), "binary");
 };
 
 Radius.ensure_array_attributes = function(attributes) {
@@ -809,10 +809,10 @@ Radius.encode_attributes = function(packet, attributes, vendor) {
           if (in_value.length == 0) {
             continue;
           }
-          out_value = new Buffer(in_value + "", "utf8");
+          out_value = Buffer.alloc(in_value + "", "utf8");
           break;
         case "ipaddr":
-          out_value = new Buffer(in_value.split("."));
+          out_value = Buffer.alloc(in_value.split("."));
           if (out_value.length != 4) {
             throw new Error("encode: invalid IP: " + in_value);
           }
@@ -821,7 +821,7 @@ Radius.encode_attributes = function(packet, attributes, vendor) {
           in_value = Math.floor(in_value.getTime() / 1000);
         case "time":
         case "integer":
-          out_value = new Buffer(4);
+          out_value = Buffer.alloc(4);
 
           in_value = attr_info[ATTR_REVERSE_ENUM][in_value] || in_value;
           if (isNaN(in_value)) {


### PR DESCRIPTION
The `new Buffer` is now deprecated and gives an error. I've changed the calls to newer method that it `Buffer.alloc`